### PR TITLE
Added a runner mechanism to let users customize simulation context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,4 @@ dist
 .pnp.*
 
 # denosim state dumps
-dumps
+runs/

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "dev": {
-      "write": ["./dumps"]
+      "read": ["runs"],
+      "write": ["runs"]
     },
     "test": {
       "read": true,
@@ -15,6 +16,7 @@
     "test": "deno test -P=test"
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@1"
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/random": "jsr:@std/random@^0.1.5"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,8 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/internal@^1.0.12": "1.0.12"
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/random@~0.1.5": "0.1.5"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -13,11 +14,15 @@
     },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/random@0.1.5": {
+      "integrity": "d26614c4f6c441afc22397a1c5b8f27d02ab8f5572f1d29e7b0cd57f3d548235"
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@1"
+      "jsr:@std/assert@1",
+      "jsr:@std/random@~0.1.5"
     ]
   }
 }

--- a/examples/er-triage.ts
+++ b/examples/er-triage.ts
@@ -1,0 +1,439 @@
+import {
+  createEvent,
+  Event,
+  get,
+  initializeSimulation,
+  initializeStore,
+  ProcessDefinition,
+  put,
+  QueueDiscipline,
+  registerProcess,
+  registerStore,
+  runSimulation,
+  scheduleEvent,
+  StateData,
+} from "../mod.ts";
+import { randomIntegerBetween, randomSeeded } from "@std/random";
+
+/**
+ * ER triage showcase:
+ * - Multiple process definitions and inherited process state
+ * - Blocking synchronization with stores (`get`/`put`)
+ * - Configurable queue discipline on stores (FIFO/LIFO)
+ * - Deterministic run with post-run correctness invariants
+ */
+
+const SIM_TIME = 1000;
+const URGENT_DOCTORS = 2;
+const GENERAL_DOCTORS = 1;
+
+const URGENT_POOL_ID = "er:urgent-pool" as const;
+const GENERAL_POOL_ID = "er:general-pool" as const;
+
+type DoctorPool = typeof URGENT_POOL_ID | typeof GENERAL_POOL_ID;
+type Urgency = "urgent" | "standard";
+
+interface DoctorToken extends StateData {
+  doctorId: string;
+  pool: DoctorPool;
+}
+
+interface PatientData extends DoctorToken {
+  patientId: number;
+  urgency: Urgency;
+  arrivalAt: number;
+  serviceTime: number;
+  startAt?: number;
+  finishAt?: number;
+}
+
+interface ArrivalState extends StateData {
+  nextId: number;
+}
+
+interface TimelineEvent {
+  at: number;
+  pool: DoctorPool;
+  delta: 1 | -1;
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(index, sorted.length - 1))];
+}
+
+interface ScenarioStats {
+  discipline: QueueDiscipline;
+  endedAt: number;
+  finished: number;
+  urgentFinished: number;
+  standardFinished: number;
+  urgentP50: number;
+  urgentP95: number;
+  standardP50: number;
+  standardP95: number;
+  maxUrgentOccupancy: number;
+  maxGeneralOccupancy: number;
+}
+
+function printKpiTable(rows: ScenarioStats[]): void {
+  const headers = [
+    "Discipline",
+    "End",
+    "Finished",
+    "Urgent",
+    "Standard",
+    "Urgent p50/p95",
+    "Standard p50/p95",
+    "Max Occ U/G",
+  ];
+  const body = rows.map((s) => [
+    s.discipline,
+    String(s.endedAt),
+    String(s.finished),
+    String(s.urgentFinished),
+    String(s.standardFinished),
+    `${s.urgentP50}/${s.urgentP95}`,
+    `${s.standardP50}/${s.standardP95}`,
+    `${s.maxUrgentOccupancy}/${s.maxGeneralOccupancy}`,
+  ]);
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...body.map((r) => r[i].length))
+  );
+  const formatRow = (cells: string[]) =>
+    cells.map((c, i) => c.padEnd(widths[i])).join(" | ");
+
+  console.log("ER Triage KPI Comparison (general pool discipline)");
+  console.log(formatRow(headers));
+  console.log(widths.map((w) => "-".repeat(w)).join("-+-"));
+
+  for (const row of body) {
+    console.log(formatRow(row));
+  }
+}
+
+function assert(condition: boolean, msg: string) {
+  if (!condition) throw new Error(`Invariant failed: ${msg}`);
+}
+
+async function runScenario(
+  discipline: QueueDiscipline,
+  seed: bigint,
+  verbose: boolean = false,
+): Promise<ScenarioStats> {
+  const prng = randomSeeded(seed);
+  const sim = initializeSimulation();
+
+  const urgentPool = initializeStore<DoctorToken, typeof URGENT_POOL_ID>({
+    id: URGENT_POOL_ID,
+    blocking: false,
+    capacity: URGENT_DOCTORS,
+    discipline: QueueDiscipline.FIFO,
+  });
+  const generalPool = initializeStore<DoctorToken, typeof GENERAL_POOL_ID>({
+    id: GENERAL_POOL_ID,
+    blocking: false,
+    capacity: GENERAL_DOCTORS,
+    discipline,
+  });
+
+  sim.stores = registerStore(sim, urgentPool);
+  sim.stores = registerStore(sim, generalPool);
+
+  for (let i = 0; i < URGENT_DOCTORS; i += 1) {
+    const token: DoctorToken = {
+      doctorId: `U${i + 1}`,
+      pool: URGENT_POOL_ID,
+    };
+    const seedEvent = createEvent<DoctorToken>(sim, {
+      scheduledAt: 0,
+      process: { type: "none", data: token },
+    });
+    put(sim, seedEvent, urgentPool.id, token);
+  }
+
+  for (let i = 0; i < GENERAL_DOCTORS; i += 1) {
+    const token: DoctorToken = {
+      doctorId: `G${i + 1}`,
+      pool: GENERAL_POOL_ID,
+    };
+    const seedEvent = createEvent<DoctorToken>(sim, {
+      scheduledAt: 0,
+      process: { type: "none", data: token },
+    });
+    put(sim, seedEvent, generalPool.id, token);
+  }
+
+  const patient: ProcessDefinition<{
+    arrive: [PatientData, StateData[]];
+    waitDoctor: [PatientData, StateData[]];
+    treat: [PatientData, StateData[]];
+    done: [PatientData, StateData[]];
+  }> = {
+    type: "patient",
+    initial: "arrive",
+    steps: {
+      arrive(sim, event, state) {
+        const { patientId, urgency, pool } = state.data;
+        if (verbose) {
+          console.log(
+            `[${sim.currentTime}] Patient ${patientId} (${urgency}) arrives`,
+          );
+        }
+
+        const wait = get(sim, event, pool);
+        return {
+          state: { ...state, step: "waitDoctor" },
+          next: [wait.step],
+        };
+      },
+      waitDoctor(sim, event, state) {
+        const token = event.process.data as DoctorToken | undefined;
+        if (!token?.doctorId) {
+          throw new Error(
+            `Missing doctor token for patient ${state.data.patientId}`,
+          );
+        }
+
+        const started = sim.currentTime;
+        const updated: PatientData = {
+          ...state.data,
+          doctorId: token.doctorId,
+          startAt: started,
+        };
+        if (verbose) {
+          console.log(
+            `[${sim.currentTime}] Patient ${updated.patientId} starts with ${token.doctorId} (${updated.pool})`,
+          );
+        }
+
+        return {
+          state: { ...state, step: "treat", data: updated },
+          next: [
+            createEvent(sim, {
+              parent: event.id,
+              scheduledAt: sim.currentTime + updated.serviceTime,
+              process: {
+                ...event.process,
+                inheritStep: true,
+              },
+            }),
+          ],
+        };
+      },
+      treat(sim, event, state) {
+        const { patientId, doctorId, pool } = state.data;
+        if (!doctorId) {
+          throw new Error(`Missing doctorId for patient ${patientId}`);
+        }
+
+        const finished: PatientData = {
+          ...state.data,
+          finishAt: sim.currentTime,
+        };
+        if (verbose) {
+          console.log(
+            `[${sim.currentTime}] Patient ${patientId} leaves (doctor ${doctorId})`,
+          );
+        }
+
+        const releaseEvent = createEvent<DoctorToken>(sim, {
+          parent: event.id,
+          scheduledAt: sim.currentTime,
+          process: { type: "none" },
+        });
+        const release = put(sim, releaseEvent, pool, { doctorId, pool });
+        return {
+          state: { ...state, step: "done", data: finished },
+          next: release.resume
+            ? [release.step, release.resume]
+            : [release.step],
+        };
+      },
+      done(_sim, _event, state) {
+        return { state, next: [] };
+      },
+    },
+  };
+
+  const arrivals: ProcessDefinition<{
+    run: [ArrivalState, StateData[]];
+  }> = {
+    type: "arrivals",
+    initial: "run",
+    steps: {
+      run(sim, event, state) {
+        const urgency: Urgency = randomIntegerBetween(1, 10, { prng }) <= 3
+          ? "urgent"
+          : "standard";
+        const pool: DoctorPool = urgency === "urgent"
+          ? URGENT_POOL_ID
+          : GENERAL_POOL_ID;
+        const serviceTime = urgency === "urgent"
+          ? randomIntegerBetween(10, 18, { prng })
+          : randomIntegerBetween(4, 10, { prng });
+
+        const patientData: PatientData = {
+          patientId: state.data.nextId,
+          urgency,
+          arrivalAt: sim.currentTime,
+          serviceTime,
+          doctorId: "",
+          pool,
+        };
+
+        const nextId = state.data.nextId + 1;
+        const events: Event[] = [
+          createEvent(sim, {
+            scheduledAt: sim.currentTime,
+            process: {
+              type: "patient",
+              data: patientData,
+            },
+          }),
+        ];
+
+        const interArrival = randomIntegerBetween(1, 8, { prng });
+        const nextAt = sim.currentTime + interArrival;
+        if (nextAt <= SIM_TIME) {
+          events.push(
+            createEvent(sim, {
+              parent: event.id,
+              scheduledAt: nextAt,
+              priority: -1,
+              process: {
+                type: "arrivals",
+                inheritStep: true,
+                data: { nextId },
+              },
+            }),
+          );
+        }
+
+        return {
+          state: { ...state, data: { nextId } },
+          next: events,
+        };
+      },
+    },
+  };
+
+  sim.registry = registerProcess(sim, patient);
+  sim.registry = registerProcess(sim, arrivals);
+
+  const start = createEvent(sim, {
+    scheduledAt: 0,
+    process: {
+      type: "arrivals",
+      data: { nextId: 1 },
+    },
+  });
+  sim.events = scheduleEvent(sim, start);
+
+  const stop = createEvent(sim, { scheduledAt: SIM_TIME });
+  sim.events = scheduleEvent(sim, stop);
+
+  const [done] = await runSimulation(sim, { untilEvent: stop });
+
+  const latestByPatient = new Map<number, PatientData>();
+  for (const processState of Object.values(done.state)) {
+    if (processState.type !== "patient") continue;
+    const data = processState.data as Partial<PatientData>;
+    if (typeof data.patientId !== "number") continue;
+    const current = latestByPatient.get(data.patientId);
+    if (
+      !current ||
+      (data.finishAt ?? -Infinity) >= (current.finishAt ?? -Infinity)
+    ) {
+      latestByPatient.set(data.patientId, data as PatientData);
+    }
+  }
+
+  const finished = [...latestByPatient.values()].filter((p) =>
+    p.finishAt !== undefined
+  );
+  const urgent = finished.filter((p) => p.urgency === "urgent");
+  const standard = finished.filter((p) => p.urgency === "standard");
+
+  const urgentWaits = urgent.map((p) =>
+    (p.startAt ?? p.arrivalAt) - p.arrivalAt
+  );
+  const standardWaits = standard.map((p) =>
+    (p.startAt ?? p.arrivalAt) - p.arrivalAt
+  );
+
+  for (const p of finished) {
+    assert(
+      (p.startAt ?? Infinity) >= p.arrivalAt,
+      `patient ${p.patientId} starts before arrival`,
+    );
+    assert(
+      (p.finishAt ?? -Infinity) >= (p.startAt ?? Infinity),
+      `patient ${p.patientId} finishes before start`,
+    );
+  }
+
+  const capacityByPool: Record<DoctorPool, number> = {
+    [URGENT_POOL_ID]: URGENT_DOCTORS,
+    [GENERAL_POOL_ID]: GENERAL_DOCTORS,
+  };
+  const occupancy: Record<DoctorPool, number> = {
+    [URGENT_POOL_ID]: 0,
+    [GENERAL_POOL_ID]: 0,
+  };
+  const maxSeen: Record<DoctorPool, number> = {
+    [URGENT_POOL_ID]: 0,
+    [GENERAL_POOL_ID]: 0,
+  };
+
+  const timeline: TimelineEvent[] = [];
+  for (const p of finished) {
+    timeline.push({ at: p.startAt!, pool: p.pool, delta: 1 });
+    timeline.push({ at: p.finishAt!, pool: p.pool, delta: -1 });
+  }
+
+  for (const t of timeline.sort((a, b) => a.at - b.at || a.delta - b.delta)) {
+    occupancy[t.pool] += t.delta;
+    assert(
+      occupancy[t.pool] >= 0,
+      `negative occupancy for ${t.pool} at t=${t.at}`,
+    );
+    assert(
+      occupancy[t.pool] <= capacityByPool[t.pool],
+      `capacity exceeded for ${t.pool} at t=${t.at}`,
+    );
+    maxSeen[t.pool] = Math.max(maxSeen[t.pool], occupancy[t.pool]);
+  }
+
+  const urgentP95 = percentile(urgentWaits, 95);
+  const standardP95 = percentile(standardWaits, 95);
+  assert(
+    urgentP95 <= standardP95,
+    `urgent p95 (${urgentP95}) should be <= standard p95 (${standardP95})`,
+  );
+
+  return {
+    discipline,
+    endedAt: done.currentTime,
+    finished: finished.length,
+    urgentFinished: urgent.length,
+    standardFinished: standard.length,
+    urgentP50: percentile(urgentWaits, 50),
+    urgentP95,
+    standardP50: percentile(standardWaits, 50),
+    standardP95,
+    maxUrgentOccupancy: maxSeen[URGENT_POOL_ID],
+    maxGeneralOccupancy: maxSeen[GENERAL_POOL_ID],
+  };
+}
+
+if (import.meta.main) {
+  const seed = 1n;
+
+  const fifo = await runScenario(QueueDiscipline.FIFO, seed);
+  const lifo = await runScenario(QueueDiscipline.LIFO, seed);
+
+  printKpiTable([fifo, lifo]);
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,6 @@
 export * from "./src/memory.ts";
 export * from "./src/model.ts";
 export * from "./src/resources.ts";
+export * from "./src/runner.ts";
 export * from "./src/serialize.ts";
 export * from "./src/simulation.ts";

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -7,45 +7,6 @@ import {
   StoreID,
   Timestamp,
 } from "./model.ts";
-import { serializeSimulation } from "./serialize.ts";
-
-/**
- * Determine if it's time to dump the current simulation state based on the configured interval and the number of deltas accumulated since the last dump.
- */
-export function shouldDump(
-  deltaEncoded: DeltaEncodedSimulation,
-): boolean {
-  return deltaEncoded.deltas.length >=
-    deltaEncoded.current.dump.config.interval;
-}
-
-/**
- * Dump the current simulation state to disk and return an updated simulation with incremented dump count.
- * Files are written to the configured directory with a sequential naming pattern (e.g., dump-0.json, dump-1.json, etc.).
- */
-export async function dumpToDisk(
-  deltaEncoded: DeltaEncodedSimulation,
-): Promise<Simulation> {
-  const dumpPath =
-    `${deltaEncoded.current.dump.config.directory}/dump-${deltaEncoded.current.dump.count}.json`;
-
-  // Persist all current simulation history
-  const serialized = serializeSimulation(deltaEncoded);
-  // FIXME: Do not await, write asynchronously
-  await Deno.writeTextFile(dumpPath, serialized);
-
-  console.log(
-    `[${deltaEncoded.current.currentTime}] Dumped ${deltaEncoded.deltas.length} simulation steps to ${dumpPath}`,
-  );
-
-  return {
-    ...deltaEncoded.current,
-    dump: {
-      config: deltaEncoded.current.dump.config,
-      count: deltaEncoded.current.dump.count + 1,
-    },
-  };
-}
 
 /** Delta operations for events */
 type EventDeltaOp =
@@ -195,7 +156,6 @@ export function applyDelta(
     events: [...base.events],
     state: { ...base.state },
     stores: { ...base.stores },
-    dump: { ...base.dump },
   };
 
   // Apply event operations

--- a/src/model.ts
+++ b/src/model.ts
@@ -41,22 +41,6 @@ export interface Simulation<
 
   /** Current state of all stores in the simulation, used for process synchronization */
   stores: StoreDefinitions<S>;
-
-  /**
-   * Configuration and count for automatic simulation dumps.
-   * Used to periodically save simulation state to disk.
-   */
-  dump: { config: DumpConfig; count: number };
-}
-
-export interface DumpConfig {
-  /**
-   * Directory where simulation dumps will be saved. Must be configured before running the simulation to enable dumping.
-   */
-  directory: string;
-
-  /** Working set of deltas between dumps */
-  interval: number;
 }
 
 /**
@@ -360,6 +344,21 @@ export interface RunSimulationOptions<T extends StateData = StateData> {
 
   /** Stop simulation when this specific event finishes */
   untilEvent?: Event<T>;
+
+  /** Optional run identifier. Defaults to a random UUID. */
+  runId?: string;
+
+  /**
+   * Explicit run directory path. If omitted, defaults to `$runs/run-${runId}`.
+   * If `run.json` exists in this directory, it is merged as run defaults.
+   */
+  runDirectory?: string;
+
+  /** Overrides the simulation dump interval for this run. */
+  dumpInterval?: number;
+
+  /** Optional metadata merged into `run.json` for this run. */
+  runMetadata?: Record<string, unknown>;
 }
 
 /**

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,0 +1,155 @@
+import { DeltaEncodedSimulation } from "./memory.ts";
+import { RunSimulationOptions } from "./model.ts";
+import { serializeSimulation } from "./serialize.ts";
+
+interface RunDumpMetadata {
+  directory: string;
+  interval: number;
+  count: number;
+  lastFile?: string;
+}
+
+interface RunManifest {
+  runId: string;
+  createdAt: string;
+  updatedAt: string;
+  runRoot: string;
+  dump: RunDumpMetadata;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Context for managing simulation runs, including dump file management and run metadata persistence.
+ * This is used to configure and track long-running simulations, allowing for periodic state dumps and resumption.
+ */
+export interface RunContext {
+  /** Base directory for the simulation run, where metadata and dumps are stored. */
+  runRoot: string;
+
+  /** Directory for storing simulation dumps, relative to `runRoot`. */
+  dumpDirectory: string;
+
+  /** Path to the run manifest file (`run.json`) within `runRoot`. */
+  manifestPath: string;
+
+  /** In-memory representation of the run manifest, used for tracking run metadata and dump state. */
+  manifest: RunManifest;
+}
+
+const DEFAULT_RUNS_DIR = "runs";
+const DEFAULT_DUMP_DIR = "dumps";
+const DEFAULT_DUMP_INTERVAL = 1000;
+
+/**
+ * Reads the run manifest from disk if it exists, or returns an empty object if not.
+ * The manifest contains metadata about the simulation run, including dump configuration and run metadata.
+ * This allows for resuming runs with existing metadata and dump state.
+ */
+async function readManifest(path: string): Promise<Partial<RunManifest>> {
+  try {
+    const raw = await Deno.readTextFile(path);
+    return JSON.parse(raw) as Partial<RunManifest>;
+  } catch (_err) {
+    return {};
+  }
+}
+
+/**
+ * Determine if it's time to dump the current simulation state based on the configured interval and the number of deltas accumulated since the last dump.
+ */
+export function shouldDump(
+  deltaEncoded: DeltaEncodedSimulation,
+  interval: number,
+): boolean {
+  return deltaEncoded.deltas.length >= interval;
+}
+
+/**
+ * Dump the current simulation state to disk and return dump file details.
+ * Files are written to the run dump directory using the configured sequence/time pattern.
+ * The file name uses a simple monotonic sequence and simulation time, e.g. `1-t100.json`.
+ * This allows for easy identification of dump files and their corresponding simulation times.
+ */
+export async function dumpToDisk(
+  deltaEncoded: DeltaEncodedSimulation,
+  runContext: RunContext,
+): Promise<void> {
+  const fileName =
+    `${runContext.manifest.dump.count}-t${deltaEncoded.current.currentTime}.json`;
+  const dumpPath = `${runContext.dumpDirectory}/${fileName}`;
+
+  // Persist all current simulation history
+  const serialized = serializeSimulation(deltaEncoded);
+  // FIXME: Do not await, write asynchronously
+  await Deno.writeTextFile(dumpPath, serialized);
+
+  runContext.manifest.dump.count += 1;
+  runContext.manifest.dump.lastFile = fileName;
+
+  await persistRunManifest(runContext);
+}
+
+/**
+ * Resolves the run context for a simulation run, including setting up directories and manifest state.
+ * If a run manifest already exists, it will be read and used to populate the context; otherwise, a new manifest will be created.
+ * This function ensures that the necessary directories exist and that the run manifest is initialized with the appropriate metadata.
+ */
+export async function resolveRunContext(
+  options?: RunSimulationOptions,
+): Promise<RunContext> {
+  const runId = options?.runId ?? crypto.randomUUID();
+  const runRoot = options?.runDirectory ?? `${DEFAULT_RUNS_DIR}/run-${runId}`;
+  const manifestPath = `${runRoot}/run.json`;
+
+  const previous = await readManifest(manifestPath);
+
+  const dumpDirectory = previous.dump?.directory ??
+    `${runRoot}/${DEFAULT_DUMP_DIR}`;
+  const dumpInterval = options?.dumpInterval ?? previous.dump?.interval ??
+    DEFAULT_DUMP_INTERVAL;
+
+  await Deno.mkdir(runRoot, { recursive: true });
+  await Deno.mkdir(dumpDirectory, { recursive: true });
+
+  const now = new Date().toISOString();
+  const manifest: RunManifest = {
+    runId: options?.runId ?? previous.runId ?? runId,
+    runRoot,
+    createdAt: previous.createdAt ?? now,
+    updatedAt: now,
+    dump: {
+      directory: dumpDirectory,
+      interval: dumpInterval,
+      count: previous.dump?.count ?? 0,
+      lastFile: previous.dump?.lastFile,
+    },
+    metadata: {
+      ...(previous.metadata ?? {}),
+      ...(options?.runMetadata ?? {}),
+    },
+  };
+
+  await Deno.writeTextFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+  return {
+    runRoot,
+    dumpDirectory,
+    manifestPath,
+    manifest,
+  };
+}
+
+/**
+ * Persists the run manifest to disk, updating the `updatedAt` timestamp.
+ * This should be called whenever the run manifest is updated, such as after creating a new dump or updating run metadata.
+ * By keeping the manifest up-to-date on disk, we ensure that the run state can be accurately resumed in case of interruption.
+ */
+export async function persistRunManifest(
+  runContext: RunContext,
+): Promise<void> {
+  runContext.manifest.updatedAt = new Date().toISOString();
+  await Deno.writeTextFile(
+    runContext.manifestPath,
+    JSON.stringify(runContext.manifest, null, 2),
+  );
+}

--- a/tests/simulation.test.ts
+++ b/tests/simulation.test.ts
@@ -954,3 +954,21 @@ Deno.test("process state inheritance (spawn)", async () => {
 
   const [_stop, _stats] = await runSimulation(sim);
 });
+
+Deno.test("simulation rate > 0 executes throttled path", async () => {
+  const sim = initializeSimulation();
+  const event = createEvent(sim, { scheduledAt: 0 });
+  sim.events = scheduleEvent(sim, event);
+
+  const [stop] = await runSimulation(sim, { rate: 1_000_000 });
+  assertEquals(stop.events[0].status, EventState.Finished);
+});
+
+Deno.test("simulation negative rate falls back to zero-delay branch", async () => {
+  const sim = initializeSimulation();
+  const event = createEvent(sim, { scheduledAt: 0 });
+  sim.events = scheduleEvent(sim, event);
+
+  const [stop] = await runSimulation(sim, { rate: -1 });
+  assertEquals(stop.events[0].status, EventState.Finished);
+});


### PR DESCRIPTION
Avoids having dump folders all around, and persists simulation context in a JSON file. Also allows users to pass arbitrary metadata to their simulations.