### PR TITLE
Event transitions and simulation runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,20 @@ Planned features:
 **Concurrency / composition model**
 
 - Child processes are spawned by emitting new events; parent–child relationships are tracked via parent on events;
-- Two spawn styles supported: inheritance (`fork`-like -- child inherits parent data and step) and fresh (`exec`-like -- clean state from process definition);
-- Blocking is modeled by a `Waiting` state and by conditional event emission (timeouts, explicit continuations).
+- Three spawn styles supported: `fork`-like continuation (child keeps parent process type and current progress/state); `exec`-like inheritance (child inherits parent data but starts at the process initial step) and `execve`-like spawn (clean state from process definition and explicitly provided input data);
+- Blocking is modeled by a `Waiting` event state and by resumption through newly emitted continuation events when conditions are satisfied.
 
 **Continuations & temporal patterns**
 
-- Supports explicit continuations and timeouts: processes can yield future events as continuations or schedule timed events to model delays.
+- Process logic is continuation-driven: each step returns the next event(s) that carry execution forward;
+- A process step does not "loop": state-machine progress happens only through emitted next event(s), including revisiting the same step in a later transition;
+- "Sleeping" is modeled by returning a continuation scheduled in the future.
 
 **Messaging / data flow**
 
 - Data flows via process data and step inheritance flags;
-- Events contain a `ProcessCall` that can carry initialization data for process state; child processes can merge inherited state.
+- Events contain a `ProcessCall` that can carry initialization data for process state; child processes can merge inherited state;
+- This lets workflows evolve over multiple events (*e.g.*, arrive -> wait -> handle -> done) while carrying context forward.
 
 ## Setup
 

--- a/deno.json
+++ b/deno.json
@@ -1,19 +1,12 @@
 {
   "permissions": {
-    "dev": {
-      "read": ["runs"],
-      "write": ["runs"]
-    },
     "test": {
       "read": ["runs"],
       "write": ["runs"]
     }
   },
   "tasks": {
-    "example_er_triage": "deno run -P=dev --v8-flags=--prof examples/er-triage.ts",
-    "example_scheduling": "deno run -P=dev --watch examples/scheduling.ts",
-    "example_synchronization": "deno run -P=dev --watch examples/synchronization.ts",
-    "example_stack_size": "deno run -P=dev --v8-flags=--prof examples/stack-size.ts",
+    "profile": "deno run -P=test --v8-flags=--prof examples/stack-size.ts",
     "test": "deno test -P=test --coverage"
   },
   "imports": {

--- a/deno.json
+++ b/deno.json
@@ -10,10 +10,11 @@
     }
   },
   "tasks": {
+    "example_er_triage": "deno run -P=dev --v8-flags=--prof examples/er-triage.ts",
     "example_scheduling": "deno run -P=dev --watch examples/scheduling.ts",
     "example_synchronization": "deno run -P=dev --watch examples/synchronization.ts",
-    "example_stack_size": "deno run -P=dev --watch examples/stack-size.ts",
-    "test": "deno test -P=test"
+    "example_stack_size": "deno run -P=dev --v8-flags=--prof examples/stack-size.ts",
+    "test": "deno test -P=test --coverage"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",

--- a/deno.json
+++ b/deno.json
@@ -5,8 +5,8 @@
       "write": ["runs"]
     },
     "test": {
-      "read": true,
-      "write": true
+      "read": ["runs"],
+      "write": ["runs"]
     }
   },
   "tasks": {

--- a/examples/er-triage.ts
+++ b/examples/er-triage.ts
@@ -23,7 +23,7 @@ import { randomIntegerBetween, randomSeeded } from "@std/random";
  * - Deterministic run with post-run correctness invariants
  */
 
-const SIM_TIME = 5000;
+const SIM_TIME = 1000;
 const URGENT_DOCTORS = 2;
 const GENERAL_DOCTORS = 1;
 
@@ -147,7 +147,7 @@ async function runScenario(
       doctorId: `U${i + 1}`,
       pool: URGENT_POOL_ID,
     };
-    const seedEvent = createEvent<DoctorToken>(sim, {
+    const seedEvent = createEvent<DoctorToken>({
       scheduledAt: 0,
       process: { type: "none", data: token },
     });
@@ -159,7 +159,7 @@ async function runScenario(
       doctorId: `G${i + 1}`,
       pool: GENERAL_POOL_ID,
     };
-    const seedEvent = createEvent<DoctorToken>(sim, {
+    const seedEvent = createEvent<DoctorToken>({
       scheduledAt: 0,
       process: { type: "none", data: token },
     });
@@ -212,7 +212,7 @@ async function runScenario(
         return {
           state: { ...state, step: "treat", data: updated },
           next: [
-            createEvent(sim, {
+            createEvent({
               parent: event.id,
               scheduledAt: sim.currentTime + updated.serviceTime,
               process: {
@@ -239,7 +239,7 @@ async function runScenario(
           );
         }
 
-        const releaseEvent = createEvent<DoctorToken>(sim, {
+        const releaseEvent = createEvent<DoctorToken>({
           parent: event.id,
           scheduledAt: sim.currentTime,
           process: { type: "none" },
@@ -286,7 +286,7 @@ async function runScenario(
 
         const nextId = state.data.nextId + 1;
         const events: Event[] = [
-          createEvent(sim, {
+          createEvent({
             scheduledAt: sim.currentTime,
             process: {
               type: "patient",
@@ -299,7 +299,7 @@ async function runScenario(
         const nextAt = sim.currentTime + interArrival;
         if (nextAt <= SIM_TIME) {
           events.push(
-            createEvent(sim, {
+            createEvent({
               parent: event.id,
               scheduledAt: nextAt,
               priority: -1,
@@ -323,17 +323,17 @@ async function runScenario(
   sim.registry = registerProcess(sim, patient);
   sim.registry = registerProcess(sim, arrivals);
 
-  const start = createEvent(sim, {
+  const start = createEvent({
     scheduledAt: 0,
     process: {
       type: "arrivals",
       data: { nextId: 1 },
     },
   });
-  sim.events = scheduleEvent(sim, start);
+  sim.timeline = scheduleEvent(sim, start);
 
-  const stop = createEvent(sim, { scheduledAt: SIM_TIME });
-  sim.events = scheduleEvent(sim, stop);
+  const stop = createEvent({ scheduledAt: SIM_TIME });
+  sim.timeline = scheduleEvent(sim, stop);
 
   const [done] = await runSimulation(sim, { untilEvent: stop });
 

--- a/examples/er-triage.ts
+++ b/examples/er-triage.ts
@@ -23,7 +23,7 @@ import { randomIntegerBetween, randomSeeded } from "@std/random";
  * - Deterministic run with post-run correctness invariants
  */
 
-const SIM_TIME = 1000;
+const SIM_TIME = 5000;
 const URGENT_DOCTORS = 2;
 const GENERAL_DOCTORS = 1;
 

--- a/examples/er-triage.ts
+++ b/examples/er-triage.ts
@@ -1,18 +1,19 @@
+import { randomIntegerBetween, randomSeeded } from "@std/random";
+
 import {
   Event,
   ProcessDefinition,
   QueueDiscipline,
   StateData,
 } from "../src/model.ts";
+import { get, initializeStore, put, registerStore } from "../src/resources.ts";
+import { runSimulation } from "../src/runner.ts";
 import {
   createEvent,
   initializeSimulation,
   registerProcess,
-  runSimulation,
   scheduleEvent,
 } from "../src/simulation.ts";
-import { get, initializeStore, put, registerStore } from "../src/resources.ts";
-import { randomIntegerBetween, randomSeeded } from "@std/random";
 
 /**
  * ER triage showcase:
@@ -336,10 +337,10 @@ async function runScenario(
   const stop = createEvent({ scheduledAt: SIM_TIME });
   sim.timeline = scheduleEvent(sim, stop);
 
-  const [done] = await runSimulation(sim, { untilEvent: stop });
+  const { result } = await runSimulation(sim, { untilEvent: stop });
 
   const latestByPatient = new Map<number, PatientData>();
-  for (const processState of Object.values(done.state)) {
+  for (const processState of Object.values(result.state)) {
     if (processState.type !== "patient") continue;
     const data = processState.data as Partial<PatientData>;
     if (typeof data.patientId !== "number") continue;
@@ -417,7 +418,7 @@ async function runScenario(
 
   return {
     discipline,
-    endedAt: done.currentTime,
+    endedAt: result.currentTime,
     finished: finished.length,
     urgentFinished: urgent.length,
     standardFinished: standard.length,

--- a/examples/scheduling.ts
+++ b/examples/scheduling.ts
@@ -78,7 +78,7 @@ if (import.meta.main) {
             },
           },
           next: [
-            createEvent(sim, {
+            createEvent({
               parent: event.id,
               scheduledAt: sim.currentTime,
               process: {
@@ -103,7 +103,7 @@ if (import.meta.main) {
               step: "stop",
             },
             next: [
-              createEvent(sim, {
+              createEvent({
                 scheduledAt: sim.currentTime,
                 process: {
                   type: "step1",
@@ -117,17 +117,14 @@ if (import.meta.main) {
           };
         } else {
           // Still waiting
-          const nextEvent: Event<TimeoutData> = createEvent(
-            sim,
-            {
-              parent: event.id,
-              scheduledAt: targetTime, // Schedule exactly at completion time
-              process: {
-                type: "bar",
-                inheritStep: true, // Continue from parent's state
-              },
+          const nextEvent: Event<TimeoutData> = createEvent({
+            parent: event.id,
+            scheduledAt: targetTime, // Schedule exactly at completion time
+            process: {
+              type: "bar",
+              inheritStep: true, // Continue from parent's state
             },
-          );
+          });
 
           return {
             state: { ...state, step: "wait" },
@@ -168,7 +165,7 @@ if (import.meta.main) {
             },
           },
           next: [
-            createEvent(sim, {
+            createEvent({
               parent: event.id,
               scheduledAt: sim.currentTime,
               process: {
@@ -193,7 +190,7 @@ if (import.meta.main) {
               step: "stop",
             },
             next: [
-              createEvent(sim, {
+              createEvent({
                 scheduledAt: sim.currentTime,
                 process: {
                   type: "step2",
@@ -203,17 +200,14 @@ if (import.meta.main) {
           };
         } else {
           // Still waiting
-          const nextEvent = createEvent(
-            sim,
-            {
-              parent: event.id,
-              scheduledAt: targetTime,
-              process: {
-                type: "step1",
-                inheritStep: true, // Continue from parent's state
-              },
+          const nextEvent = createEvent({
+            parent: event.id,
+            scheduledAt: targetTime,
+            process: {
+              type: "step1",
+              inheritStep: true, // Continue from parent's state
             },
-          );
+          });
 
           return {
             state: { ...state, step: "wait" },
@@ -273,7 +267,6 @@ if (import.meta.main) {
             },
           },
           next: [createEvent(
-            sim,
             {
               parent: event.id,
               scheduledAt: sim.currentTime,
@@ -299,7 +292,6 @@ if (import.meta.main) {
             },
             next: [
               createEvent(
-                sim,
                 {
                   scheduledAt: sim.currentTime,
                   process: {
@@ -314,7 +306,6 @@ if (import.meta.main) {
           };
         } else {
           const nextEvent: Event<TimeoutData> = createEvent(
-            sim,
             {
               parent: event.id,
               scheduledAt: targetTime,
@@ -342,35 +333,35 @@ if (import.meta.main) {
 
   sim.registry = registerProcess(sim, bazCb);
 
-  const e1 = createEvent(sim, {
+  const e1 = createEvent({
     scheduledAt: 10,
     process: { type: "foo", data: { "from": "main" } },
   });
-  sim.events = scheduleEvent(sim, e1);
+  sim.timeline = scheduleEvent(sim, e1);
 
-  const e2 = createEvent(sim, { scheduledAt: 20, process: { type: "bar" } });
-  sim.events = scheduleEvent(sim, e2);
+  const e2 = createEvent({ scheduledAt: 20, process: { type: "bar" } });
+  sim.timeline = scheduleEvent(sim, e2);
 
-  const e3 = createEvent(sim, {
+  const e3 = createEvent({
     scheduledAt: 30,
     process: { type: "foo", data: { "from": "main" } },
   });
-  sim.events = scheduleEvent(sim, e3);
+  sim.timeline = scheduleEvent(sim, e3);
 
-  const e4 = createEvent(sim, {
+  const e4 = createEvent({
     scheduledAt: 37,
     process: { type: "foo", data: { "from": "main" } },
   });
-  sim.events = scheduleEvent(sim, e4);
+  sim.timeline = scheduleEvent(sim, e4);
 
-  const e5 = createEvent(sim, {
+  const e5 = createEvent({
     scheduledAt: 50,
     process: { type: "foo", data: { "from": "main" } },
   });
-  sim.events = scheduleEvent(sim, e5);
+  sim.timeline = scheduleEvent(sim, e5);
 
-  const e6 = createEvent(sim, { scheduledAt: 60, process: { type: "baz" } });
-  sim.events = scheduleEvent(sim, e6);
+  const e6 = createEvent({ scheduledAt: 60, process: { type: "baz" } });
+  sim.timeline = scheduleEvent(sim, e6);
 
   const [stop, stats] = await runSimulation(sim);
 

--- a/examples/scheduling.ts
+++ b/examples/scheduling.ts
@@ -1,13 +1,11 @@
+import { Event, ProcessDefinition, StateData } from "../src/model.ts";
 import {
   createEvent,
-  Event,
   initializeSimulation,
-  ProcessDefinition,
   registerProcess,
   runSimulation,
   scheduleEvent,
-  StateData,
-} from "../mod.ts";
+} from "../src/simulation.ts";
 
 /**
  * Expected output:
@@ -40,7 +38,7 @@ if (import.meta.main) {
   const sim = initializeSimulation();
 
   const fooCb: ProcessDefinition<{
-    none: [FooData, []];
+    none: FooData;
   }> = {
     type: "foo",
     initial: "none",
@@ -58,9 +56,9 @@ if (import.meta.main) {
   sim.registry = registerProcess(sim, fooCb);
 
   const barCb: ProcessDefinition<{
-    start: [TimeoutData, [TimeoutData]];
-    wait: [TimeoutData, [TimeoutData]];
-    stop: [TimeoutData, []];
+    start: TimeoutData;
+    wait: TimeoutData;
+    stop: TimeoutData;
   }> = {
     type: "bar",
     initial: "start",
@@ -145,9 +143,9 @@ if (import.meta.main) {
   sim.registry = registerProcess(sim, barCb);
 
   const step1Cb: ProcessDefinition<{
-    start: [TimeoutData, [TimeoutData]];
-    wait: [TimeoutData, [StateData | TimeoutData]];
-    stop: [TimeoutData, []];
+    start: TimeoutData;
+    wait: TimeoutData;
+    stop: TimeoutData;
   }> = {
     type: "step1",
     initial: "start",
@@ -227,7 +225,7 @@ if (import.meta.main) {
   sim.registry = registerProcess(sim, step1Cb);
 
   const step2Cb: ProcessDefinition<{
-    none: [StateData, []];
+    none: StateData;
   }> = {
     type: "step2",
     initial: "none",
@@ -247,9 +245,9 @@ if (import.meta.main) {
   sim.registry = registerProcess(sim, step2Cb);
 
   const bazCb: ProcessDefinition<{
-    start: [TimeoutData, [TimeoutData]];
-    wait: [TimeoutData, [StateData | TimeoutData]];
-    stop: [TimeoutData, []];
+    start: TimeoutData;
+    wait: TimeoutData;
+    stop: TimeoutData;
   }> = {
     type: "baz",
     initial: "start",

--- a/examples/scheduling.ts
+++ b/examples/scheduling.ts
@@ -1,9 +1,9 @@
 import { Event, ProcessDefinition, StateData } from "../src/model.ts";
+import { runSimulation } from "../src/runner.ts";
 import {
   createEvent,
   initializeSimulation,
   registerProcess,
-  runSimulation,
   scheduleEvent,
 } from "../src/simulation.ts";
 
@@ -361,8 +361,8 @@ if (import.meta.main) {
   const e6 = createEvent({ scheduledAt: 60, process: { type: "baz" } });
   sim.timeline = scheduleEvent(sim, e6);
 
-  const [stop, stats] = await runSimulation(sim);
+  const { result, stats } = await runSimulation(sim);
 
-  console.log(`Simulation ended at ${stop.currentTime}`);
+  console.log(`Simulation ended at ${result.currentTime}`);
   console.log(`Simulation took: ${stats.duration} ms`);
 }

--- a/examples/spawn-paths.ts
+++ b/examples/spawn-paths.ts
@@ -1,0 +1,123 @@
+import {
+  createEvent,
+  Event,
+  initializeSimulation,
+  ProcessDefinition,
+  registerProcess,
+  runSimulation,
+  scheduleEvent,
+  StateData,
+} from "../mod.ts";
+
+interface DriverData extends StateData {
+  shared: number;
+  tag?: string;
+}
+
+interface WorkerData extends StateData {
+  own: string;
+  shared?: number;
+}
+
+const observations: string[] = [];
+
+const driver: ProcessDefinition<{
+  start: [DriverData, [DriverData, WorkerData, WorkerData]];
+  done: [DriverData, []];
+}> = {
+  type: "driver",
+  initial: "start",
+  steps: {
+    start(sim, event, state) {
+      observations.push(
+        `[t=${sim.currentTime}] driver:start shared=${state.data.shared}`,
+      );
+      const nextShared = 42;
+
+      // 1) CONTINUATION (fork-like): same process type + inheritStep=true
+      const continuation: Event<DriverData> = createEvent<DriverData>(sim, {
+        parent: event.id,
+        scheduledAt: 1,
+        process: {
+          type: "driver",
+          inheritStep: true,
+          data: { shared: nextShared, tag: "continued" },
+        },
+      });
+
+      // 2) NEW PROCESS WITH PARENT DATA (exec-like): parent linked, fresh initial step
+      const inheritedSpawn: Event<WorkerData> = createEvent(sim, {
+        parent: event.id,
+        scheduledAt: 2,
+        process: {
+          type: "worker",
+          data: { own: "exec-like" },
+        },
+      });
+
+      // 3) BRAND NEW PROCESS (execve-like): no parent, only explicit input data
+      const freshSpawn: Event<WorkerData> = createEvent(sim, {
+        scheduledAt: 3,
+        process: {
+          type: "worker",
+          data: { own: "execve-like" },
+        },
+      });
+
+      return {
+        state: {
+          ...state,
+          step: "done",
+          data: { ...state.data, shared: nextShared },
+        },
+        next: [continuation, inheritedSpawn, freshSpawn],
+      };
+    },
+    done(sim, _event, state) {
+      observations.push(
+        `[t=${sim.currentTime}] driver:done shared=${state.data.shared} tag=${state.data.tag}`,
+      );
+      return { state, next: [] };
+    },
+  },
+};
+
+const worker: ProcessDefinition<{
+  start: [WorkerData, []];
+}> = {
+  type: "worker",
+  initial: "start",
+  steps: {
+    start(sim, _event, state) {
+      observations.push(
+        `[t=${sim.currentTime}] worker:${state.data.own} shared=${state.data.shared}`,
+      );
+      return { state, next: [] };
+    },
+  },
+};
+
+if (import.meta.main) {
+  const sim = initializeSimulation();
+  sim.registry = registerProcess(sim, driver);
+  sim.registry = registerProcess(sim, worker);
+
+  const root = createEvent(sim, {
+    scheduledAt: 0,
+    process: {
+      type: "driver",
+      data: { shared: 7 },
+    },
+  });
+  sim.events = scheduleEvent(sim, root);
+
+  await runSimulation(sim);
+
+  // Expected:
+  // - continuation keeps driver progress and sees shared=42
+  // - exec-like worker inherits parent shared=42
+  // - execve-like worker has no inherited shared
+  for (const line of observations) {
+    console.log(line);
+  }
+}

--- a/examples/spawn-paths.ts
+++ b/examples/spawn-paths.ts
@@ -35,7 +35,7 @@ const driver: ProcessDefinition<{
       const nextShared = 42;
 
       // 1) CONTINUATION (fork-like): same process type + inheritStep=true
-      const continuation: Event<DriverData> = createEvent<DriverData>(sim, {
+      const continuation: Event<DriverData> = createEvent({
         parent: event.id,
         scheduledAt: 1,
         process: {
@@ -46,7 +46,7 @@ const driver: ProcessDefinition<{
       });
 
       // 2) NEW PROCESS WITH PARENT DATA (exec-like): parent linked, fresh initial step
-      const inheritedSpawn: Event<WorkerData> = createEvent(sim, {
+      const inheritedSpawn: Event<WorkerData> = createEvent({
         parent: event.id,
         scheduledAt: 2,
         process: {
@@ -56,7 +56,7 @@ const driver: ProcessDefinition<{
       });
 
       // 3) BRAND NEW PROCESS (execve-like): no parent, only explicit input data
-      const freshSpawn: Event<WorkerData> = createEvent(sim, {
+      const freshSpawn: Event<WorkerData> = createEvent({
         scheduledAt: 3,
         process: {
           type: "worker",
@@ -102,14 +102,14 @@ if (import.meta.main) {
   sim.registry = registerProcess(sim, driver);
   sim.registry = registerProcess(sim, worker);
 
-  const root = createEvent(sim, {
+  const root = createEvent({
     scheduledAt: 0,
     process: {
       type: "driver",
       data: { shared: 7 },
     },
   });
-  sim.events = scheduleEvent(sim, root);
+  sim.timeline = scheduleEvent(sim, root);
 
   await runSimulation(sim);
 

--- a/examples/spawn-paths.ts
+++ b/examples/spawn-paths.ts
@@ -1,13 +1,11 @@
+import { Event, ProcessDefinition, StateData } from "../src/model.ts";
 import {
   createEvent,
-  Event,
   initializeSimulation,
-  ProcessDefinition,
   registerProcess,
   runSimulation,
   scheduleEvent,
-  StateData,
-} from "../mod.ts";
+} from "../src/simulation.ts";
 
 interface DriverData extends StateData {
   shared: number;
@@ -22,8 +20,8 @@ interface WorkerData extends StateData {
 const observations: string[] = [];
 
 const driver: ProcessDefinition<{
-  start: [DriverData, [DriverData, WorkerData, WorkerData]];
-  done: [DriverData, []];
+  start: DriverData;
+  done: DriverData;
 }> = {
   type: "driver",
   initial: "start",
@@ -83,7 +81,7 @@ const driver: ProcessDefinition<{
 };
 
 const worker: ProcessDefinition<{
-  start: [WorkerData, []];
+  start: WorkerData;
 }> = {
   type: "worker",
   initial: "start",

--- a/examples/spawn-paths.ts
+++ b/examples/spawn-paths.ts
@@ -1,9 +1,9 @@
 import { Event, ProcessDefinition, StateData } from "../src/model.ts";
+import { runSimulation } from "../src/runner.ts";
 import {
   createEvent,
   initializeSimulation,
   registerProcess,
-  runSimulation,
   scheduleEvent,
 } from "../src/simulation.ts";
 

--- a/examples/stack-size.ts
+++ b/examples/stack-size.ts
@@ -31,7 +31,7 @@ if (import.meta.main) {
           }; got count = ${state.data["count"]}`,
         );
 
-        const nextEvent: Event<FooData> = createEvent(sim, {
+        const nextEvent: Event<FooData> = createEvent({
           parent: event.id,
           scheduledAt: sim.currentTime < state.data["stop"]
             ? sim.currentTime + 1
@@ -68,7 +68,7 @@ if (import.meta.main) {
 
   sim.registry = registerProcess(sim, foo);
 
-  const e1 = createEvent(sim, {
+  const e1 = createEvent({
     scheduledAt: 0,
     process: {
       type: "foo",
@@ -78,7 +78,7 @@ if (import.meta.main) {
       },
     },
   });
-  sim.events = scheduleEvent(sim, e1);
+  sim.timeline = scheduleEvent(sim, e1);
 
   const [stop, stats] = await runSimulation(sim);
 

--- a/examples/stack-size.ts
+++ b/examples/stack-size.ts
@@ -1,13 +1,11 @@
+import { Event, ProcessDefinition, StateData } from "../src/model.ts";
 import {
   createEvent,
-  Event,
   initializeSimulation,
-  ProcessDefinition,
   registerProcess,
   runSimulation,
   scheduleEvent,
-  StateData,
-} from "../mod.ts";
+} from "../src/simulation.ts";
 
 if (import.meta.main) {
   const sim = initializeSimulation();
@@ -18,8 +16,8 @@ if (import.meta.main) {
   }
 
   const foo: ProcessDefinition<{
-    start: [FooData, [FooData]];
-    stop: [FooData, []];
+    start: FooData;
+    stop: FooData;
   }> = {
     type: "foo",
     initial: "start",

--- a/examples/stack-size.ts
+++ b/examples/stack-size.ts
@@ -1,9 +1,9 @@
 import { Event, ProcessDefinition, StateData } from "../src/model.ts";
+import { runSimulation } from "../src/runner.ts";
 import {
   createEvent,
   initializeSimulation,
   registerProcess,
-  runSimulation,
   scheduleEvent,
 } from "../src/simulation.ts";
 
@@ -78,8 +78,8 @@ if (import.meta.main) {
   });
   sim.timeline = scheduleEvent(sim, e1);
 
-  const [stop, stats] = await runSimulation(sim);
+  const { result, stats } = await runSimulation(sim);
 
-  console.log(`Simulation ended at ${stop.currentTime}`);
+  console.log(`Simulation ended at ${result.currentTime}`);
   console.log(`Simulation took: ${stats.duration} ms`);
 }

--- a/examples/synchronization.ts
+++ b/examples/synchronization.ts
@@ -1,12 +1,12 @@
 import { ProcessDefinition, StateData } from "../src/model.ts";
+import { get, initializeStore, put, registerStore } from "../src/resources.ts";
+import { runSimulation } from "../src/runner.ts";
 import {
   createEvent,
   initializeSimulation,
   registerProcess,
-  runSimulation,
   scheduleEvent,
 } from "../src/simulation.ts";
-import { get, initializeStore, put, registerStore } from "../src/resources.ts";
 
 if (import.meta.main) {
   const sim = initializeSimulation();
@@ -172,10 +172,10 @@ if (import.meta.main) {
   });
   sim.timeline = scheduleEvent(sim, e4);
 
-  const [stop, stats] = await runSimulation(sim);
+  const { result, stats } = await runSimulation(sim);
 
-  console.log(stop.timeline);
+  console.log(result.timeline);
 
-  console.log(`Simulation ended at ${stop.currentTime}`);
+  console.log(`Simulation ended at ${result.currentTime}`);
   console.log(`Simulation took: ${stats.duration} ms`);
 }

--- a/examples/synchronization.ts
+++ b/examples/synchronization.ts
@@ -1,6 +1,5 @@
 import {
   createEvent,
-  EventState,
   get,
   initializeSimulation,
   initializeStore,
@@ -20,11 +19,7 @@ if (import.meta.main) {
     "foo": string;
   }
 
-  const store = initializeStore<FooData>(
-    {
-      blocking: true,
-    },
-  );
+  const store = initializeStore<FooData>({});
 
   sim.stores = registerStore(sim, store);
 
@@ -51,7 +46,7 @@ if (import.meta.main) {
           `[${sim.currentTime}] prod received: step = ${step} | resume = ${resume}`,
         );
 
-        if (step.status === EventState.Waiting) {
+        if (step.waiting) {
           // Delayed
           console.log(
             `[${sim.currentTime}] prod put request for "${state.data.foo}" blocked on store ${store.id}`,
@@ -102,7 +97,7 @@ if (import.meta.main) {
           `[${sim.currentTime}] cons received: step = ${step} | resume = ${resume}`,
         );
 
-        if (step.status === EventState.Waiting) {
+        if (step.waiting) {
           // Delayed
           console.log(
             `[${sim.currentTime}] cons get request blocked on store ${store.id}`,
@@ -141,7 +136,7 @@ if (import.meta.main) {
 
   sim.registry = registerProcess(sim, cons);
 
-  const e1 = createEvent(sim, {
+  const e1 = createEvent({
     scheduledAt: 0,
     process: {
       type: "prod",
@@ -150,25 +145,25 @@ if (import.meta.main) {
       },
     },
   });
-  sim.events = scheduleEvent(sim, e1);
+  sim.timeline = scheduleEvent(sim, e1);
 
-  const e2 = createEvent(sim, {
+  const e2 = createEvent({
     scheduledAt: 1,
     process: {
       type: "cons",
     },
   });
-  sim.events = scheduleEvent(sim, e2);
+  sim.timeline = scheduleEvent(sim, e2);
 
-  const e3 = createEvent(sim, {
+  const e3 = createEvent({
     scheduledAt: 5,
     process: {
       type: "cons",
     },
   });
-  sim.events = scheduleEvent(sim, e3);
+  sim.timeline = scheduleEvent(sim, e3);
 
-  const e4 = createEvent(sim, {
+  const e4 = createEvent({
     scheduledAt: 10,
     process: {
       type: "prod",
@@ -177,11 +172,11 @@ if (import.meta.main) {
       },
     },
   });
-  sim.events = scheduleEvent(sim, e4);
+  sim.timeline = scheduleEvent(sim, e4);
 
   const [stop, stats] = await runSimulation(sim);
 
-  console.log(stop.events);
+  console.log(stop.timeline);
 
   console.log(`Simulation ended at ${stop.currentTime}`);
   console.log(`Simulation took: ${stats.duration} ms`);

--- a/src/model.ts
+++ b/src/model.ts
@@ -19,7 +19,7 @@ export interface Simulation<
 
   /**
    * Full lifecycle record for every event in the simulation.
-   * Combines immutable event definitions with the append-only transition log and derived indexes that make common queries (current status, pending events) O(1).
+   * Combines immutable event definitions with the append-only transition log and derived status index that makes queries O(1).
    */
   timeline: Timeline;
 
@@ -356,6 +356,17 @@ export interface SimulationStats {
 
   /** Real-world time (in milliseconds) the simulation took to complete */
   duration: number;
+}
+
+/**
+ * TODO:
+ */
+export interface SimulationResult<T> {
+  /** TODO: */
+  result: T;
+
+  /** TODO: */
+  stats: SimulationStats;
 }
 
 /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -196,7 +196,7 @@ export interface StoreResult<T extends StateData = StateData> {
   /**
    * TODO:
    */
-  finish?: EventID[];
+  finish?: Event[];
 }
 
 /** Timestamp for simulation clock */
@@ -282,8 +282,12 @@ export interface ProcessCall<T extends StateData = StateData> {
   data?: T;
 }
 
-type ValidProcessState<M extends StepStateMap> = {
-  [K in keyof M]: { type: ProcessType; step: K; data: M[K] };
+// type ValidProcessState<M extends StepStateMap> = {
+//   [K in keyof M]: { type: ProcessType; step: K; data: M[K] };
+// }[keyof M];
+
+type ProcessStateFor<M extends StepStateMap> = {
+  [K in keyof M]: ProcessState<M[K], K & StepType>;
 }[keyof M];
 
 /**
@@ -324,7 +328,7 @@ export interface ProcessState<
  */
 export interface ProcessStep<M extends StepStateMap = StepStateMap> {
   /** Process handler returns the updated state of the process */
-  state: ValidProcessState<M>;
+  state: ProcessStateFor<M>;
 
   /**
    * Process handler returns the next events to be scheduled.
@@ -337,7 +341,7 @@ export interface ProcessStep<M extends StepStateMap = StepStateMap> {
   /**
    * TODO:
    */
-  finish?: EventID[];
+  finish?: Event[];
 }
 
 /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -108,7 +108,7 @@ export interface EventTransition {
  * Events can be tied to processes, which define their behavior.
  * Event definitions are immutable; lifecycle progression is represented through `EventTransition` entries.
  * Events can have parent-child relationships in the context of their process.
- * TODO: They can be created with a `waiting` attribute that...
+ * Events can be created with a `waiting` attribute that places them directly in `EventState.Waiting`, preventing their execution until they are explicitly resumed.
  * Events scheduled at the same timestamp will be selected based on their priority (the lower the value, the higher the priority). In case of a tie, the scheduler dequeues events in a LIFO fashion.
  */
 export interface Event<T extends StateData = StateData> {
@@ -118,7 +118,7 @@ export interface Event<T extends StateData = StateData> {
   /** Optional parent event ID; defines a graph of events across processes */
   parent?: EventID;
 
-  /** TODO: */
+  /** If `true`, the event will not be scheduled for process execution */
   waiting?: boolean;
 
   /**
@@ -194,7 +194,8 @@ export interface StoreResult<T extends StateData = StateData> {
   resume?: Event<T>[];
 
   /**
-   * TODO:
+   * Events to explicitly mark as `Finished` as a side effect of the store operation.
+   * Typically used to clean up waiting request events once the blocked condition they represent has been resolved.
    */
   finish?: Event[];
 }
@@ -339,7 +340,8 @@ export interface ProcessStep<M extends StepStateMap = StepStateMap> {
   next: Event[];
 
   /**
-   * TODO:
+   * Optional events to explicitly mark as `Finished` after this step.
+   * Used when the handler needs to terminate events currently in `EventState.Waiting`.
    */
   finish?: Event[];
 }
@@ -359,13 +361,14 @@ export interface SimulationStats {
 }
 
 /**
- * TODO:
+ * Return value of a completed simulation run.
+ * Bundles the final simulation along with run statistics.
  */
 export interface SimulationResult<T> {
-  /** TODO: */
+  /** Final simulation representation after the run completes */
   result: T;
 
-  /** TODO: */
+  /** Statistics for the completed run */
   stats: SimulationStats;
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -17,13 +17,9 @@ export interface Simulation<
   currentTime: Timestamp;
 
   /**
-   * Queue of all events in the system.
-   * Includes:
-   * - Newly scheduled but not yet processed events
-   * - Partially processed events, which have related process execution state
-   * - Completed events (for historical tracking)
+   * TODO:
    */
-  events: Event[];
+  timeline: Timeline;
 
   /**
    * Registry of all process definitions available in the simulation.
@@ -44,16 +40,31 @@ export interface Simulation<
 }
 
 /**
+ * TODO:
+ */
+export interface Timeline {
+  /**
+   * Event definitions keyed by event ID.
+   */
+  events: Record<EventID, Event>;
+
+  /**
+   * TODO:
+   */
+  status: Record<EventID, EventState>;
+
+  /**
+   * Append-only lifecycle log for event state transitions.
+   * This is the source of truth for event progression.
+   */
+  transitions: EventTransition[];
+}
+
+/**
  * Lifecycle states for events within the simulation.
  * Events progress through states with possible blocking at Waiting.
  */
 export enum EventState {
-  /**
-   * Initial state when event is first created.
-   * Indicates the event has been instantiated but not yet scheduled.
-   */
-  Fired = "Fired",
-
   /**
    * Event has been scheduled for future processing.
    * Will be executed when simulation time reaches `scheduledAt`.
@@ -74,10 +85,22 @@ export enum EventState {
   Finished = "Finished",
 }
 
+/** Append-only event lifecycle transition entry */
+export interface EventTransition {
+  /** Event identifier affected by this transition */
+  id: EventID;
+
+  /** Lifecycle state reached by the event */
+  state: EventState;
+
+  /** Simulation timestamp when the transition occurred */
+  at: Timestamp;
+}
+
 /**
  * Represents a discrete event in the simulation system.
  * Events can be tied to processes, which define their behavior.
- * Events are immutable - state changes are tied to new event instances.
+ * Event definitions are immutable; lifecycle progression is represented through `EventTransition` entries.
  * Events can have parent-child relationships in the context of their process.
  */
 export interface Event<T extends StateData = StateData> {
@@ -87,8 +110,10 @@ export interface Event<T extends StateData = StateData> {
   /** Optional parent event ID; defines a graph of events across processes */
   parent?: EventID;
 
-  /** Current lifecycle state of the event */
-  status: EventState;
+  /**
+   * TODO:
+   */
+  waiting?: boolean;
 
   /**
    * Optional event priority for scheduling; lower value yields higher priority (cf. UNIX `nice`).
@@ -97,22 +122,10 @@ export interface Event<T extends StateData = StateData> {
   priority: number;
 
   /**
-   * When the event was initially created.
-   * Represents the simulation time when `createEvent()` was called.
-   */
-  firedAt: Timestamp;
-
-  /**
    * When the event should be processed.
    * Simulation time will jump directly to this value when processed.
    */
   scheduledAt: Timestamp;
-
-  /**
-   * When the event completed processing.
-   * Only populated when `status` is `EventState.Finished`.
-   */
-  finishedAt?: Timestamp;
 
   /**
    * Type of process to execute when event is handled.

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -136,7 +136,7 @@ export function put<
       },
     });
 
-    return { step: updatedPut, resume: updatedGet };
+    return { step: updatedPut, resume: [updatedGet], finish: [getRequest.id] };
   }
 
   // Blocking store or non-blocking store without pending get request: block put
@@ -248,7 +248,7 @@ export function get<
       },
     });
 
-    return { step: updatedGet, resume: updatedPut };
+    return { step: updatedGet, resume: [updatedPut], finish: [putRequest.id] };
   }
 
   // Non-blocking store: check buffer (completed puts)

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -117,7 +117,7 @@ export function put<
     };
 
     // Reschedule the get request with the data attached
-    const updatedGet: Event<T> = createEvent<T>(sim, {
+    const updatedGet: Event<T> = createEvent({
       parent: getRequest.parent,
       scheduledAt: sim.currentTime,
       process: {
@@ -127,7 +127,7 @@ export function put<
       },
     });
 
-    const updatedPut: Event<T> = createEvent(sim, {
+    const updatedPut: Event<T> = createEvent({
       parent: event.id,
       scheduledAt: sim.currentTime,
       process: {
@@ -143,7 +143,7 @@ export function put<
   if (
     store.blocking || (!store.blocking && store.buffer.length >= store.capacity)
   ) {
-    const updatedPut: Event<T> = createEvent(sim, {
+    const updatedPut: Event<T> = createEvent({
       parent: event.id,
       waiting: true,
       scheduledAt: sim.currentTime,
@@ -166,7 +166,7 @@ export function put<
   }
 
   // Non-blocking store with capacity available: use buffer
-  const updatedPut: Event<T> = createEvent(sim, {
+  const updatedPut: Event<T> = createEvent({
     parent: event.id,
     scheduledAt: sim.currentTime,
     process: {
@@ -228,7 +228,7 @@ export function get<
       );
     }
 
-    const updatedPut: Event<T> = createEvent<T>(sim, {
+    const updatedPut: Event<T> = createEvent({
       parent: putRequest.parent,
       scheduledAt: sim.currentTime,
       process: {
@@ -238,7 +238,7 @@ export function get<
       },
     });
 
-    const updatedGet = createEvent<T>(sim, {
+    const updatedGet = createEvent({
       parent: event.id,
       scheduledAt: sim.currentTime,
       process: {
@@ -272,7 +272,7 @@ export function get<
       );
     }
 
-    const updatedGet = createEvent<T>(sim, {
+    const updatedGet = createEvent({
       parent: event.id,
       scheduledAt: sim.currentTime,
       process: {
@@ -286,7 +286,7 @@ export function get<
   }
 
   // No data available: wait in queue
-  const updatedGet = createEvent(sim, {
+  const updatedGet = createEvent({
     parent: event.id,
     scheduledAt: sim.currentTime,
     waiting: true,

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -136,7 +136,7 @@ export function put<
       },
     });
 
-    return { step: updatedPut, resume: [updatedGet], finish: [getRequest.id] };
+    return { step: updatedPut, resume: [updatedGet], finish: [getRequest] };
   }
 
   // Blocking store or non-blocking store without pending get request: block put
@@ -248,7 +248,7 @@ export function get<
       },
     });
 
-    return { step: updatedGet, resume: [updatedPut], finish: [putRequest.id] };
+    return { step: updatedGet, resume: [updatedPut], finish: [putRequest] };
   }
 
   // Non-blocking store: check buffer (completed puts)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -310,6 +310,11 @@ export async function reconstructFullCurrent(
   return mergeReplayState(full, tail);
 }
 
+/**
+ * Merges two simulation states for full-history reconstruction after a run with checkpoints.
+ * Used to fold checkpoint snapshots together with the in-memory tail into a single replay-complete simulation state.
+ * Events and statuses from `current` take precedence over `previous`; transitions are concatenated in chronological order.
+ */
 function mergeReplayState(
   previous: Simulation,
   current: Simulation,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,5 +1,18 @@
-import { DeltaEncodedSimulation } from "./memory.ts";
-import { RunSimulationOptions } from "./model.ts";
+import {
+  createDelta,
+  DeltaEncodedSimulation,
+  pruneWorkingState,
+} from "./memory.ts";
+import {
+  Event,
+  EventID,
+  EventState,
+  RunSimulationOptions,
+  Simulation,
+  SimulationResult,
+} from "./model.ts";
+import { deserializeSimulation, serializeSimulation } from "./serialize.ts";
+import { run, shouldTerminate } from "./simulation.ts";
 
 interface RunDumpMetadata {
   directory: string;
@@ -96,7 +109,7 @@ export async function dumpToDisk(
   };
   runContext.manifest = nextManifest;
 
-  await persistRunManifest(runContext);
+  await persistRunManifest(runContext.manifest, runContext.manifestPath);
 
   return {
     path: dumpPath,
@@ -144,7 +157,7 @@ export async function resolveRunContext(
     },
   };
 
-  await Deno.writeTextFile(manifestPath, JSON.stringify(manifest, null, 2));
+  await persistRunManifest(manifest, manifestPath);
 
   return {
     runRoot,
@@ -155,16 +168,184 @@ export async function resolveRunContext(
 }
 
 /**
- * Persists the run manifest to disk, updating the `updatedAt` timestamp.
+ * Persists the run manifest to disk.
  * This should be called whenever the run manifest is updated, such as after creating a new dump or updating run metadata.
  * By keeping the manifest up-to-date on disk, we ensure that the run state can be accurately resumed in case of interruption.
  */
 export async function persistRunManifest(
-  runContext: RunContext,
+  manifest: RunManifest,
+  manifestPath: string,
 ): Promise<void> {
-  runContext.manifest.updatedAt = new Date().toISOString();
   await Deno.writeTextFile(
-    runContext.manifestPath,
-    JSON.stringify(runContext.manifest, null, 2),
+    manifestPath,
+    JSON.stringify(manifest, null, 2),
   );
+}
+
+/**
+ * Runs the discrete-event simulation until:
+ * - either no more events remain to process;
+ * - or the simulation time reaches at least the specified `until` time;
+ * - or the simulation reaches a point where the specified `until` event is processed.
+ * The simulation processes events in chronological order (earliest first).
+ * Playback speed can be adjusted by passing a simulation rate (expressed in Hz).
+ * Returns the final simulation state along with statistics about the run.
+ */
+export async function runSimulation(
+  init: Simulation,
+  options?: RunSimulationOptions,
+): Promise<SimulationResult<Simulation>> {
+  const { result, stats } = await runSimulationWithDeltas(init, options);
+
+  return {
+    result: result.current,
+    stats,
+  };
+}
+
+/**
+ * Runs the simulation and exposes the delta/checkpoint representation.
+ * Layers on memory management: delta accumulation, periodic checkpoint dumps, state pruning, and final reconstruction from disk when checkpoints have been written.
+ */
+export async function runSimulationWithDeltas(
+  init: Simulation,
+  options?: RunSimulationOptions,
+): Promise<SimulationResult<DeltaEncodedSimulation>> {
+  const runContext = await resolveRunContext(options);
+  const dumpInterval = runContext.manifest.dump.interval;
+
+  const encoded: DeltaEncodedSimulation = {
+    base: { ...init },
+    deltas: [],
+    current: { ...init },
+  };
+  const checkpoints: string[] = [];
+  const result = {
+    current: init,
+  };
+
+  const start = performance.now();
+  while (true) {
+    const [next, continuation] = run(result.current);
+    if (!continuation) break;
+    result.current = next;
+
+    encoded.deltas.push(createDelta(encoded.current, result.current));
+    encoded.current = result.current;
+
+    if (options?.rate) await delay(options.rate);
+    if (options && shouldTerminate(result.current, options)) break;
+
+    if (shouldDump(encoded, dumpInterval)) {
+      const checkpoint = await dumpToDisk(
+        serializeSimulation(encoded),
+        encoded.current.currentTime,
+        runContext,
+      );
+      checkpoints.push(checkpoint.path);
+      const compacted = pruneWorkingState(result.current);
+      encoded.base = compacted;
+      encoded.deltas = [];
+      encoded.current = compacted;
+      result.current = compacted;
+    }
+  }
+
+  const stop = performance.now();
+  if (checkpoints.length > 0) {
+    const current = await reconstructFullCurrent(checkpoints, encoded.current);
+    encoded.base = current;
+    encoded.deltas = [];
+    encoded.current = current;
+  }
+
+  return {
+    result: encoded,
+    stats: {
+      end: encoded.current.currentTime,
+      duration: stop - start,
+    },
+  };
+}
+
+/**
+ * Helper function to introduce a wall-clock delay based on desired simulation rate (in Hz).
+ * If rate is not provided, executes immediately.
+ * Otherwise, computes delay in milliseconds and times out accordingly.
+ */
+function delay(rate: number): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(resolve, rate > 0 ? 1000 / rate : 0)
+  );
+}
+
+/**
+ * Reconstructs a full current state from checkpoint files and an in-memory tail.
+ * This restores replay-complete state for run outputs while allowing in-run pruning.
+ */
+export async function reconstructFullCurrent(
+  checkpoints: string[],
+  tail: Simulation,
+): Promise<Simulation> {
+  const snapshots = await Promise.all(
+    checkpoints.map(async (checkpoint) => {
+      const states = deserializeSimulation(
+        await Deno.readTextFile(checkpoint),
+        tail.registry,
+      );
+      return states[states.length - 1];
+    }),
+  );
+
+  if (snapshots.length === 0) {
+    return tail;
+  }
+
+  const [first, ...rest] = snapshots;
+  const full = rest.reduce(
+    (acc, current) => mergeReplayState(acc, current),
+    first,
+  );
+
+  return mergeReplayState(full, tail);
+}
+
+function mergeReplayState(
+  previous: Simulation,
+  current: Simulation,
+): Simulation {
+  const eventsById: Record<string, Event> = {
+    ...previous.timeline.events,
+  };
+
+  for (const [id, event] of Object.entries(current.timeline.events)) {
+    eventsById[id] = event;
+  }
+
+  const statusById: Record<EventID, EventState> = {
+    ...previous.timeline.status,
+  };
+
+  for (const [id, status] of Object.entries(current.timeline.status)) {
+    statusById[id] = status;
+  }
+
+  const transitions = [
+    ...previous.timeline.transitions,
+    ...current.timeline.transitions,
+  ];
+
+  return {
+    ...current,
+    timeline: {
+      ...current.timeline,
+      events: eventsById,
+      status: statusById,
+      transitions,
+    },
+    state: {
+      ...previous.state,
+      ...current.state,
+    },
+  };
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,6 +1,5 @@
-import { ProcessRegistry } from "../mod.ts";
 import { DeltaEncodedSimulation, reconstructFromDeltas } from "./memory.ts";
-import { Simulation } from "./model.ts";
+import { ProcessRegistry, Simulation } from "./model.ts";
 
 /**
  * The whole simulation should be completely serializable to JSON.

--- a/src/simulation.ts
+++ b/src/simulation.ts
@@ -305,6 +305,11 @@ export function scheduleEvent<T extends StateData>(
   };
 }
 
+/**
+ * Closes an event's lifecycle in the timeline by marking it `Finished`.
+ * Because the timeline is append-only and events are never deleted, this signals completion and excludes the event from future scheduling.
+ * Returns an updated Timeline with the event's status marked as `Finished` and the corresponding transition appended.
+ */
 export function finishEvent<T extends StateData>(
   sim: Simulation,
   event: Event<T>,

--- a/src/simulation.ts
+++ b/src/simulation.ts
@@ -293,8 +293,8 @@ function step(sim: Simulation, event: Event): Simulation {
   }
 
   // Finish the old events yielded by the current process if necessary
-  for (const finishId of finish ?? []) {
-    nextSim.timeline = finishEvent(nextSim, sim.timeline.events[finishId]);
+  for (const finishedEvent of finish ?? []) {
+    nextSim.timeline = finishEvent(nextSim, sim.timeline.events[finishedEvent.id]);
   }
 
   return nextSim;

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -164,7 +164,7 @@ Deno.test("applyDelta applies store set/delete operations", () => {
   assert(result.stores["s2"]);
 });
 
-Deno.test("runSimulation records only real steps and dumps every interval window", async () => {
+Deno.test("runSimulation records only real steps and keeps full final state after dumps", async () => {
   const dir = "dumps-cadence";
   await Deno.remove(dir, { recursive: true }).catch(() => {});
 
@@ -180,13 +180,13 @@ Deno.test("runSimulation records only real steps and dumps every interval window
     dumpInterval: 2,
   });
 
-  assertEquals(encoded.current.events.length, 5);
+  assertEquals(encoded.current.currentTime, 4);
   assert(
     encoded.current.events.every((event) =>
       event.status === EventState.Finished
     ),
   );
-  assertEquals(encoded.deltas.length, 1);
+  assertEquals(encoded.deltas.length, 0);
 
   const dump0 = await Deno.stat(`${dir}/dumps/0-t1.json`);
   const dump1 = await Deno.stat(`${dir}/dumps/1-t3.json`);

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,161 +1,77 @@
 import { assert, assertEquals } from "@std/assert";
+
 import {
   applyDelta,
   createDelta,
   createDeltaEncodedSimulation,
+  pruneWorkingState,
   reconstructFromDeltas,
+  reconstructFullCurrent,
 } from "../src/memory.ts";
 import {
   Event,
-  EventID,
   EventState,
-  ProcessState,
+  EventTransition,
+  ProcessDefinition,
   QueueDiscipline,
-  Simulation,
+  StateData,
 } from "../src/model.ts";
+import { registerStore } from "../src/resources.ts";
 import {
   createEvent,
   initializeSimulation,
+  registerProcess,
   runSimulation,
   runSimulationWithDeltas,
   scheduleEvent,
 } from "../src/simulation.ts";
-import { EventTransition, registerStore } from "../mod.ts";
-
-function makeSim(
-  time = 0,
-  events: Record<string, Event> = {},
-  status: Record<EventID, EventState> = {},
-  transitions: EventTransition[] = [],
-  state: Record<string, ProcessState> = {},
-  stores: Record<string, unknown> = {},
-): Simulation {
-  return {
-    currentTime: time,
-    timeline: {
-      events,
-      status,
-      transitions,
-    },
-    state,
-    stores: stores as Simulation["stores"],
-    registry: {},
-  };
-}
 
 Deno.test("createDelta captures event/state/store mutations", () => {
-  const e1: Event = {
-    id: "e1",
-    priority: 0,
-    scheduledAt: 0,
-    process: { type: "none" },
-  };
-  const e1Finished: Event = {
-    ...e1,
-  };
-  const e2: Event = {
-    id: "e2",
-    priority: 0,
-    scheduledAt: 2,
-    process: { type: "none" },
-  };
+  // Create initial simulation state using proper API
+  const sim1 = initializeSimulation();
+  const e1 = createEvent({ scheduledAt: 0 });
+  sim1.timeline = scheduleEvent(sim1, e1);
 
-  const sim1 = makeSim(
-    0,
-    { [e1.id]: e1 },
-    { [e1.id]: EventState.Scheduled },
-    [],
-    {
-      e1: { type: "p", step: "start", data: { n: 1 } },
-    },
-    {
-      s1: {
-        id: "s1",
-        capacity: 1,
-        blocking: true,
-        buffer: [],
-        getRequests: [],
-        putRequests: [],
-      },
-    },
-  );
-
-  const sim2 = makeSim(
-    2,
-    { [e1Finished.id]: e1Finished, [e2.id]: e2 },
-    { [e1.id]: EventState.Finished, [e2.id]: EventState.Scheduled },
-    [{ id: e1.id, state: EventState.Finished, at: 2 }],
-    {
-      e1: { type: "p", step: "start", data: { n: 1 } },
-      e2: { type: "p", step: "start", data: { n: 3 } },
-    },
-    {
-      s1: {
-        id: "s1",
-        capacity: 1,
-        blocking: true,
-        buffer: [],
-        getRequests: [e1],
-        putRequests: [],
-      },
-      s2: {
-        id: "s2",
-        capacity: 1,
-        blocking: true,
-        buffer: [],
-        getRequests: [],
-        putRequests: [],
-      },
-    },
-  );
+  // Create second simulation state with additional event
+  const sim2 = initializeSimulation();
+  const e2 = createEvent({ scheduledAt: 2 });
+  sim2.timeline = scheduleEvent(sim2, e2);
+  sim2.currentTime = 2;
 
   const delta = createDelta(sim1, sim2);
   assertEquals(delta.c, 2);
   assertEquals(delta.e.length, 1);
-  assert(delta.e.some((op) => op.op === "set" && op.key === "e2"));
-  assertEquals(delta.s.length, 1);
-  assert(delta.s.some((op) => op.key === "e2"));
-  assertEquals(delta.st.length, 2);
-  assert(delta.st.some((op) => op.op === "set" && op.key === "s1"));
-  assert(delta.st.some((op) => op.op === "set" && op.key === "s2"));
+  assert(delta.e.some((op) => op.op === "set" && op.key === e2.id));
 });
 
 Deno.test("delta encoding roundtrip reconstructs final state", () => {
-  const sim0 = makeSim(0);
-  const sim1 = makeSim(1, {}, {}, [], {
-    a: { type: "p", step: "s1", data: {} },
-  });
-  const sim2 = makeSim(2, {}, {}, [], {
-    a: { type: "p", step: "s2", data: {} },
-  });
+  const sim0 = initializeSimulation();
+  const sim1 = initializeSimulation();
+  sim1.currentTime = 1;
+  const sim2 = initializeSimulation();
+  sim2.currentTime = 2;
 
   const encoded = createDeltaEncodedSimulation([sim0, sim1, sim2]);
   const recovered = reconstructFromDeltas(encoded.base, encoded.deltas);
 
   assertEquals(recovered.length, 3);
-  assertEquals(recovered[2], sim2);
+  assertEquals(recovered[2].currentTime, 2);
 });
 
 Deno.test("applyDelta applies store set operations", () => {
+  const base = initializeSimulation();
   const req = createEvent({ scheduledAt: 0 });
-  const base = makeSim(
-    0,
-    {},
-    {},
-    [],
-    {},
-    {
-      s1: {
-        id: "s1",
-        capacity: 1,
-        blocking: true,
-        discipline: QueueDiscipline.LIFO,
-        buffer: [],
-        getRequests: [req],
-        putRequests: [],
-      },
+  base.stores = {
+    s1: {
+      id: "s1",
+      capacity: 1,
+      blocking: true,
+      discipline: QueueDiscipline.LIFO,
+      buffer: [],
+      getRequests: [req],
+      putRequests: [],
     },
-  );
+  };
 
   const result = applyDelta(base, {
     c: 1,
@@ -217,6 +133,227 @@ Deno.test("runSimulation records only real steps and keeps full final state afte
   assert(dump1.isFile);
 
   await Deno.remove(dir, { recursive: true });
+});
+
+Deno.test("reconstructFullCurrent merges checkpoint files with in-memory state", async () => {
+  const dir = "reconstruct-full-current-test";
+  await Deno.remove(dir, { recursive: true }).catch(() => {});
+
+  // Create a simple process
+  const sim = initializeSimulation();
+  const simpleProcess: ProcessDefinition<{
+    start: StateData;
+  }> = {
+    type: "reconstruct-test",
+    initial: "start",
+    steps: {
+      start: (_sim, _event, state) => {
+        return {
+          state: { ...state, completed: true },
+          next: [],
+        };
+      },
+    },
+  };
+
+  sim.registry = registerProcess(sim, simpleProcess);
+
+  // Create and run first checkpoint
+  const e1 = createEvent({
+    scheduledAt: 0,
+    process: { type: "reconstruct-test" },
+  });
+  sim.timeline = scheduleEvent(sim, e1);
+
+  const [_checkpoint1] = await runSimulation(sim, {
+    runDirectory: dir,
+    dumpInterval: 1,
+  });
+
+  // Create checkpoint file path
+  const checkpointFiles = [
+    `${dir}/dumps/0-t0.json`,
+  ];
+
+  // Verify checkpoint file exists
+  const checkpointStat = await Deno.stat(checkpointFiles[0]);
+  assert(checkpointStat.isFile);
+
+  // Create in-memory tail with additional events
+  const tailSim = initializeSimulation();
+  tailSim.registry = sim.registry;
+  const e2 = createEvent({
+    scheduledAt: 1,
+    process: { type: "reconstruct-test" },
+  });
+  tailSim.timeline = scheduleEvent(tailSim, e2);
+  const [tail] = await runSimulation(tailSim);
+
+  // Reconstruct full current state from checkpoints and tail
+  const reconstructed = await reconstructFullCurrent(checkpointFiles, tail);
+
+  // Verify reconstruction includes both checkpoint and tail data
+  assert(
+    reconstructed.timeline.events[e1.id] ||
+      reconstructed.timeline.events[e2.id],
+  );
+
+  // Clean up
+  await Deno.remove(dir, { recursive: true });
+});
+
+Deno.test("reconstructFullCurrent handles empty checkpoints", async () => {
+  const tail = initializeSimulation();
+
+  // Test with empty checkpoint array
+  const reconstructed = await reconstructFullCurrent([], tail);
+
+  // Should return the tail unchanged
+  assertEquals(reconstructed, tail);
+});
+
+Deno.test("pruneWorkingState filters out finished events and their transitions", () => {
+  const sim = initializeSimulation();
+
+  // Create events with different states
+  const finishedEvent = createEvent({ scheduledAt: 0 });
+  const waitingEvent = createEvent({ scheduledAt: 1 });
+
+  sim.timeline = scheduleEvent(sim, finishedEvent);
+  sim.timeline = scheduleEvent(sim, waitingEvent);
+
+  // Set up states and transitions
+  sim.state[finishedEvent.id] = { type: "p", step: "done", data: {} };
+  sim.state[waitingEvent.id] = { type: "p", step: "waiting", data: {} };
+
+  sim.timeline.status[finishedEvent.id] = EventState.Finished;
+  sim.timeline.status[waitingEvent.id] = EventState.Waiting;
+
+  sim.timeline.transitions = [
+    { id: finishedEvent.id, state: EventState.Scheduled, at: 0 },
+    { id: finishedEvent.id, state: EventState.Finished, at: 1 },
+    { id: waitingEvent.id, state: EventState.Scheduled, at: 1 },
+    { id: waitingEvent.id, state: EventState.Waiting, at: 2 },
+  ];
+
+  const pruned = pruneWorkingState(sim);
+
+  // Finished event should be removed from events
+  assert(!pruned.timeline.events[finishedEvent.id]);
+
+  // Waiting event should remain
+  assert(pruned.timeline.events[waitingEvent.id]);
+
+  // Finished event should be removed from status
+  assert(!pruned.timeline.status[finishedEvent.id]);
+
+  // Waiting event status should remain
+  assertEquals(pruned.timeline.status[waitingEvent.id], EventState.Waiting);
+
+  // Transitions for finished event should be filtered out
+  const finishedTransitions = pruned.timeline.transitions.filter((
+    t: EventTransition,
+  ) => t.id === finishedEvent.id);
+  assertEquals(finishedTransitions.length, 0);
+
+  // Transitions for waiting event should remain
+  const waitingTransitions = pruned.timeline.transitions.filter((
+    t: EventTransition,
+  ) => t.id === waitingEvent.id);
+  assertEquals(waitingTransitions.length, 2);
+});
+
+Deno.test("pruneWorkingState preserves state only for events with parent references", () => {
+  const sim = initializeSimulation();
+
+  // Create parent-child relationship
+  const parentEvent = createEvent({ scheduledAt: 0 });
+  const childEvent = createEvent({
+    scheduledAt: 1,
+    parent: parentEvent.id,
+    process: { type: "test", inheritStep: true },
+  });
+
+  sim.timeline = scheduleEvent(sim, parentEvent);
+  sim.timeline = scheduleEvent(sim, childEvent);
+
+  // Set up states
+  sim.state[parentEvent.id] = { type: "p", step: "parent", data: {} };
+  sim.state[childEvent.id] = { type: "p", step: "child", data: {} };
+
+  // Mark parent as finished, child as waiting
+  sim.timeline.status[parentEvent.id] = EventState.Finished;
+  sim.timeline.status[childEvent.id] = EventState.Waiting;
+
+  const pruned = pruneWorkingState(sim);
+
+  // Parent should be removed (finished)
+  assert(!pruned.timeline.events[parentEvent.id]);
+  assert(!pruned.timeline.status[parentEvent.id]);
+
+  // Child should remain (not finished)
+  assert(pruned.timeline.events[childEvent.id]);
+  assertEquals(pruned.timeline.status[childEvent.id], EventState.Waiting);
+
+  // Parent's state should be preserved because child references it
+  assert(pruned.state[parentEvent.id]);
+  assertEquals(pruned.state[parentEvent.id].step, "parent");
+
+  // Child's state is not preserved because no other events reference it
+  // (only parent references are tracked for state preservation)
+  assert(!pruned.state[childEvent.id]);
+});
+
+Deno.test("pruneWorkingState handles complex parent-child relationships", () => {
+  const sim = initializeSimulation();
+
+  // Create a chain: grandparent -> parent -> child
+  const grandparent = createEvent({ scheduledAt: 0 });
+  const parent = createEvent({
+    scheduledAt: 1,
+    parent: grandparent.id,
+    process: { type: "test", inheritStep: true },
+  });
+  const child = createEvent({
+    scheduledAt: 2,
+    parent: parent.id,
+    process: { type: "test", inheritStep: true },
+  });
+
+  sim.timeline = scheduleEvent(sim, grandparent);
+  sim.timeline = scheduleEvent(sim, parent);
+  sim.timeline = scheduleEvent(sim, child);
+
+  // Set up states
+  sim.state[grandparent.id] = { type: "p", step: "grandparent", data: {} };
+  sim.state[parent.id] = { type: "p", step: "parent", data: {} };
+  sim.state[child.id] = { type: "p", step: "child", data: {} };
+
+  // Mark grandparent and parent as finished, child as waiting
+  sim.timeline.status[grandparent.id] = EventState.Finished;
+  sim.timeline.status[parent.id] = EventState.Finished;
+  sim.timeline.status[child.id] = EventState.Waiting;
+
+  const pruned = pruneWorkingState(sim);
+
+  // Grandparent should be removed
+  assert(!pruned.timeline.events[grandparent.id]);
+
+  // Parent should be removed
+  assert(!pruned.timeline.events[parent.id]);
+
+  // Child should remain
+  assert(pruned.timeline.events[child.id]);
+
+  // Parent's state should be preserved (directly referenced by child)
+  assert(pruned.state[parent.id]);
+  assertEquals(pruned.state[parent.id].step, "parent");
+
+  // Grandparent's state should NOT be preserved (not directly referenced by child)
+  assert(!pruned.state[grandparent.id]);
+
+  // Child's state should NOT be preserved (no other events reference it)
+  assert(!pruned.state[child.id]);
 });
 
 Deno.test("runSimulation keeps base immutable and reconstructs current from deltas", async () => {

--- a/tests/resources.test.ts
+++ b/tests/resources.test.ts
@@ -75,9 +75,6 @@ const cons: ProcessDefinition<{
   },
 };
 
-Deno.test.beforeEach(() => {
-});
-
 Deno.test("producer-consumer synchronization with blocking", async () => {
   const sim = initializeSimulation();
 
@@ -136,7 +133,7 @@ Deno.test("producer-consumer synchronization with blocking", async () => {
   assert(Object.values(stop.state).every((state) => state.step === "stop"));
 });
 
-Deno.test("multiple consumers with single producer", async () => {
+Deno.test("multiple consumers with single producer", () => {
   const sim = initializeSimulation();
   const store = initializeStore<FooData>({
     blocking: true,
@@ -170,7 +167,7 @@ Deno.test("multiple consumers with single producer", async () => {
   assertEquals(sim.stores[store.id].getRequests.length, 1);
 });
 
-Deno.test("multiple producers with delayed consumers", async () => {
+Deno.test("multiple producers with delayed consumers", () => {
   const sim = initializeSimulation();
   const store = initializeStore<FooData>({
     blocking: true,
@@ -205,7 +202,7 @@ Deno.test("multiple producers with delayed consumers", async () => {
   assertEquals(sim.stores[store.id].putRequests.length, 1);
 });
 
-Deno.test("non-blocking store with capacity > 1", async () => {
+Deno.test("non-blocking store with capacity > 1", () => {
   const sim = initializeSimulation();
   const store = initializeStore<FooData>({
     blocking: false,
@@ -237,7 +234,7 @@ Deno.test("non-blocking store with capacity > 1", async () => {
   assertEquals(sim.stores[store.id].putRequests.length, 1);
 });
 
-Deno.test("blocking store with unlimited capacity behavior", async () => {
+Deno.test("blocking store with unlimited capacity behavior", () => {
   const sim = initializeSimulation();
   const store = initializeStore<FooData>({
     blocking: true,
@@ -256,7 +253,7 @@ Deno.test("blocking store with unlimited capacity behavior", async () => {
   assertEquals(sim.stores[store.id].buffer.length, 0);
 });
 
-Deno.test("non-blocking store with capacity 0 (immediate rejection)", async () => {
+Deno.test("non-blocking store with capacity 0 (immediate rejection)", () => {
   const sim = initializeSimulation();
   const store = initializeStore<FooData>({
     blocking: false,

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -1,39 +1,11 @@
 import { assert, assertEquals } from "@std/assert";
 import { DeltaEncodedSimulation } from "../src/memory.ts";
-import {
-  Event,
-  EventID,
-  EventState,
-  ProcessState,
-  Simulation,
-} from "../src/model.ts";
 import { dumpToDisk, resolveRunContext, shouldDump } from "../src/runner.ts";
 import { serializeSimulation } from "../src/serialize.ts";
-import { EventTransition } from "../mod.ts";
-
-function makeSim(
-  time = 0,
-  events: Record<string, Event> = {},
-  status: Record<EventID, EventState> = {},
-  transitions: EventTransition[] = [],
-  state: Record<string, ProcessState> = {},
-  stores: Record<string, unknown> = {},
-): Simulation {
-  return {
-    currentTime: time,
-    timeline: {
-      events,
-      status,
-      transitions,
-    },
-    state,
-    stores: stores as Simulation["stores"],
-    registry: {},
-  };
-}
+import { initializeSimulation } from "../src/simulation.ts";
 
 Deno.test("shouldDump depends on local delta window only", () => {
-  const sim = makeSim(0);
+  const sim = initializeSimulation();
   const deltaEncoded: DeltaEncodedSimulation = {
     base: sim,
     deltas: [{ c: 1, e: [], es: [], et: [], s: [], st: [] }],
@@ -52,7 +24,7 @@ Deno.test("dumpToDisk writes a checkpoint file", async () => {
   const dir = "run-dumps-test";
   await Deno.remove(dir, { recursive: true }).catch(() => {});
 
-  const sim = makeSim(0, {}, {}, [], {}, {});
+  const sim = initializeSimulation();
   const deltaEncoded: DeltaEncodedSimulation = {
     base: sim,
     deltas: [{ c: 1, e: [], es: [], et: [], s: [], st: [] }],

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -21,7 +21,7 @@ Deno.test("shouldDump depends on local delta window only", () => {
 });
 
 Deno.test("dumpToDisk writes a checkpoint file", async () => {
-  const dir = "run-dumps-test";
+  const dir = "runs/test/run-dumps-test";
   await Deno.remove(dir, { recursive: true }).catch(() => {});
 
   const sim = initializeSimulation();
@@ -45,7 +45,7 @@ Deno.test("dumpToDisk writes a checkpoint file", async () => {
 });
 
 Deno.test("resolveRunContext reuses existing manifest dump state", async () => {
-  const dir = "run-resume-test";
+  const dir = "runs/test/run-resume-test";
   await Deno.remove(dir, { recursive: true }).catch(() => {});
   await Deno.mkdir(dir, { recursive: true });
 
@@ -79,7 +79,7 @@ Deno.test("resolveRunContext reuses existing manifest dump state", async () => {
 });
 
 Deno.test("resolveRunContext tolerates invalid run.json and recreates defaults", async () => {
-  const dir = "run-invalid-manifest-test";
+  const dir = "runs/test/run-invalid-manifest-test";
   await Deno.remove(dir, { recursive: true }).catch(() => {});
   await Deno.mkdir(dir, { recursive: true });
   await Deno.writeTextFile(`${dir}/run.json`, "{ not valid json");

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -1,8 +1,22 @@
 import { assert, assertEquals } from "@std/assert";
+
 import { DeltaEncodedSimulation } from "../src/memory.ts";
-import { dumpToDisk, resolveRunContext, shouldDump } from "../src/runner.ts";
+import { EventState, ProcessDefinition, StateData } from "../src/model.ts";
+import {
+  dumpToDisk,
+  reconstructFullCurrent,
+  resolveRunContext,
+  runSimulation,
+  runSimulationWithDeltas,
+  shouldDump,
+} from "../src/runner.ts";
 import { serializeSimulation } from "../src/serialize.ts";
-import { initializeSimulation } from "../src/simulation.ts";
+import {
+  createEvent,
+  initializeSimulation,
+  registerProcess,
+  scheduleEvent,
+} from "../src/simulation.ts";
 
 Deno.test("shouldDump depends on local delta window only", () => {
   const sim = initializeSimulation();
@@ -94,4 +108,84 @@ Deno.test("resolveRunContext tolerates invalid run.json and recreates defaults",
   assertEquals(context.manifest.dump.count, 0);
 
   await Deno.remove(dir, { recursive: true });
+});
+
+Deno.test("reconstructFullCurrent merges checkpoint files with in-memory state", async () => {
+  const dir = "runs/test/reconstruct-full-current-test";
+  await Deno.remove(dir, { recursive: true }).catch(() => {});
+
+  // Create a simple process
+  const sim = initializeSimulation();
+  const simpleProcess: ProcessDefinition<{
+    start: StateData;
+  }> = {
+    type: "reconstruct-test",
+    initial: "start",
+    steps: {
+      start: (_sim, _event, state) => {
+        return {
+          state: { ...state, completed: true },
+          next: [],
+        };
+      },
+    },
+  };
+
+  sim.registry = registerProcess(sim, simpleProcess);
+
+  // Create and run first checkpoint
+  const e1 = createEvent({
+    scheduledAt: 0,
+    process: { type: "reconstruct-test" },
+  });
+  sim.timeline = scheduleEvent(sim, e1);
+
+  await runSimulationWithDeltas(sim, {
+    runDirectory: dir,
+    dumpInterval: 1,
+  });
+
+  // Create checkpoint file path
+  const checkpointFiles = [
+    `${dir}/dumps/0-t0.json`,
+  ];
+
+  // Verify checkpoint file exists
+  const checkpointStat = await Deno.stat(checkpointFiles[0]);
+  assert(checkpointStat.isFile);
+
+  // Create in-memory tail with additional events
+  const tailSim = initializeSimulation();
+  tailSim.registry = sim.registry;
+  const e2 = createEvent({
+    scheduledAt: 1,
+    process: { type: "reconstruct-test" },
+  });
+  tailSim.timeline = scheduleEvent(tailSim, e2);
+  const { result } = await runSimulation(tailSim);
+
+  // Reconstruct full current state from checkpoints and tail
+  const reconstructed = await reconstructFullCurrent(checkpointFiles, result);
+
+  // e1 comes from the checkpoint file, e2 from the tail — both must be present
+  assert(
+    reconstructed.timeline.events[e1.id],
+    "e1 from checkpoint must be present",
+  );
+  assert(reconstructed.timeline.events[e2.id], "e2 from tail must be present");
+  assertEquals(reconstructed.timeline.status[e1.id], EventState.Finished);
+  assertEquals(reconstructed.timeline.status[e2.id], EventState.Finished);
+
+  // Clean up
+  await Deno.remove(dir, { recursive: true });
+});
+
+Deno.test("reconstructFullCurrent handles empty checkpoints", async () => {
+  const tail = initializeSimulation();
+
+  // Test with empty checkpoint array
+  const reconstructed = await reconstructFullCurrent([], tail);
+
+  // Should return the tail unchanged
+  assertEquals(reconstructed, tail);
 });

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -1,18 +1,31 @@
 import { assert, assertEquals } from "@std/assert";
 import { DeltaEncodedSimulation } from "../src/memory.ts";
-import { Event, ProcessState, Simulation } from "../src/model.ts";
+import {
+  Event,
+  EventID,
+  EventState,
+  ProcessState,
+  Simulation,
+} from "../src/model.ts";
 import { dumpToDisk, resolveRunContext, shouldDump } from "../src/runner.ts";
 import { serializeSimulation } from "../src/serialize.ts";
+import { EventTransition } from "../mod.ts";
 
 function makeSim(
   time = 0,
-  events: Event[] = [],
+  events: Record<string, Event> = {},
+  status: Record<EventID, EventState> = {},
+  transitions: EventTransition[] = [],
   state: Record<string, ProcessState> = {},
   stores: Record<string, unknown> = {},
 ): Simulation {
   return {
     currentTime: time,
-    events,
+    timeline: {
+      events,
+      status,
+      transitions,
+    },
     state,
     stores: stores as Simulation["stores"],
     registry: {},
@@ -23,7 +36,7 @@ Deno.test("shouldDump depends on local delta window only", () => {
   const sim = makeSim(0);
   const deltaEncoded: DeltaEncodedSimulation = {
     base: sim,
-    deltas: [{ t: 1, e: [], s: [], st: [] }],
+    deltas: [{ c: 1, e: [], es: [], et: [], s: [], st: [] }],
     current: {
       ...sim,
       currentTime: 1,
@@ -31,7 +44,7 @@ Deno.test("shouldDump depends on local delta window only", () => {
   };
 
   assertEquals(shouldDump(deltaEncoded, 2), false);
-  deltaEncoded.deltas.push({ t: 2, e: [], s: [], st: [] });
+  deltaEncoded.deltas.push({ c: 2, e: [], es: [], et: [], s: [], st: [] });
   assertEquals(shouldDump(deltaEncoded, 2), true);
 });
 
@@ -39,10 +52,10 @@ Deno.test("dumpToDisk writes a checkpoint file", async () => {
   const dir = "run-dumps-test";
   await Deno.remove(dir, { recursive: true }).catch(() => {});
 
-  const sim = makeSim(0, [], {}, {});
+  const sim = makeSim(0, {}, {}, [], {}, {});
   const deltaEncoded: DeltaEncodedSimulation = {
     base: sim,
-    deltas: [{ t: 1, e: [], s: [], st: [] }],
+    deltas: [{ c: 1, e: [], es: [], et: [], s: [], st: [] }],
     current: { ...sim, currentTime: 1 },
   };
 

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -1,16 +1,17 @@
 import { assert, assertEquals } from "@std/assert";
+
+import { EventState, ProcessDefinition, StateData } from "../src/model.ts";
+import {
+  deserializeSimulation,
+  serializeSimulation,
+} from "../src/serialize.ts";
 import {
   createEvent,
-  deserializeSimulation,
-  EventState,
   initializeSimulation,
-  ProcessDefinition,
   registerProcess,
   runSimulationWithDeltas,
   scheduleEvent,
-  serializeSimulation,
-  StateData,
-} from "../mod.ts";
+} from "../src/simulation.ts";
 
 interface CounterData extends StateData {
   count: number;
@@ -18,7 +19,7 @@ interface CounterData extends StateData {
 }
 
 const counter: ProcessDefinition<{
-  tick: [CounterData, [CounterData] | []];
+  tick: CounterData;
 }> = {
   type: "counter",
   initial: "tick",
@@ -28,7 +29,6 @@ const counter: ProcessDefinition<{
         return { state, next: [] };
       }
 
-      // FIXME: Closures in handlers do not survive serialize/deserialize + eval.
       const next = createEvent({
         parent: event.id,
         scheduledAt: sim.currentTime + 1,
@@ -68,7 +68,7 @@ Deno.test("basic serialization", async () => {
   }
 
   const dummy: ProcessDefinition<{
-    start: [DummyData, []];
+    start: DummyData;
   }> = {
     type: "dummy",
     initial: "start",
@@ -210,7 +210,7 @@ Deno.test("serialize handles arrow-function handlers", async () => {
   }
 
   const arrow: ProcessDefinition<{
-    start: [ArrowData, []];
+    start: ArrowData;
   }> = {
     type: "arrow",
     initial: "start",


### PR DESCRIPTION
Events are now truly immutable. Changes in their status are modeled by `EventTransition` that are registered in the simulation's timeline in an append-only log.

Some changes were introduced to the user-facing API:
1. Step handlers can now return multiple events in `resume` (to unblock multiple processes) and `finish` (*e.g.* to mark multiple store requests as finished);
2. Simulation entrypoint now lives in the `runner.ts` module.